### PR TITLE
Fix typo in ClassConstants fixture

### DIFF
--- a/tests/Fixture/class_constants.php
+++ b/tests/Fixture/class_constants.php
@@ -7,7 +7,7 @@ class ClassConstants
     final public const EXPLICITLY_PUBLIC_CONSTANT = 'explicitly public';
 
     /* a comment might be here */
-    private const COMMENT_IN_DEFINTION = 'comment in definition';
+    private const COMMENT_IN_DEFINITION = 'comment in definition';
 
     private const PRIVATE_CONSTANT = 'private';
 


### PR DESCRIPTION
There was an "i" missing.
