### PR TITLE
Add bare files support + merge constants and functions to structure overview

### DIFF
--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -30,7 +30,7 @@ final class Analyser
     /**
      * @param string[] $filePaths
      */
-    public function measureFiles(array $filePaths): Measurements
+    public function measureFiles(array $filePaths, ?callable $progressBarClosure = null): Measurements
     {
         $measurements = new Measurements();
 
@@ -39,6 +39,10 @@ final class Analyser
 
         foreach ($filePaths as $filePath) {
             $this->measureFile($measurements, $filePath);
+
+            if (is_callable($progressBarClosure)) {
+                $progressBarClosure();
+            }
         }
 
         return $measurements;

--- a/src/Console/Command/MeasureCommand.php
+++ b/src/Console/Command/MeasureCommand.php
@@ -63,28 +63,8 @@ final class MeasureCommand extends Command
             return Command::FAILURE;
         }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-        $measurement = $this->analyser->measureFiles($filePaths);
-=======
-        $this->symfonyStyle->createProgressBar(count($filePaths));
-        $progressBarClosure = function (): void {
-=======
-        $this->symfonyStyle->createProgressBar(count($filePaths));
-        $progressBarClosure = function () {
->>>>>>> 41b8985 (misc)
-            $this->symfonyStyle->progressAdvance();
-        };
-
-=======
         $progressBarClosure = $this->createProgressBarClosure($isJson, $filePaths);
->>>>>>> 690f2ba (add progres bar)
         $measurement = $this->analyser->measureFiles($filePaths, $progressBarClosure);
-<<<<<<< HEAD
->>>>>>> a97c159 (fixup! misc)
-=======
->>>>>>> 41b8985 (misc)
 
         // print results
         if ($isJson) {
@@ -102,14 +82,14 @@ final class MeasureCommand extends Command
      */
     private function createProgressBarClosure(bool $isJson, array $filePaths): ?callable
     {
-        if ($isJson === true) {
+        if ($isJson) {
             return null;
         }
 
         $progressBar = $this->symfonyStyle->createProgressBar(count($filePaths));
         $progressBar->start();
 
-        return function () use ($progressBar): void {
+        return static function () use ($progressBar): void {
             $progressBar->advance();
         };
     }

--- a/src/Console/Command/MeasureCommand.php
+++ b/src/Console/Command/MeasureCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use TomasVotruba\Lines\Analyser;
 use TomasVotruba\Lines\Console\OutputFormatter\JsonOutputFormatter;
 use TomasVotruba\Lines\Console\OutputFormatter\TextOutputFormatter;
@@ -21,6 +22,7 @@ final class MeasureCommand extends Command
         private readonly Analyser $analyser,
         private readonly JsonOutputFormatter $jsonOutputFormatter,
         private readonly TextOutputFormatter $textOutputFormatter,
+        private readonly SymfonyStyle $symfonyStyle,
     ) {
         parent::__construct();
     }
@@ -61,7 +63,28 @@ final class MeasureCommand extends Command
             return Command::FAILURE;
         }
 
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
         $measurement = $this->analyser->measureFiles($filePaths);
+=======
+        $this->symfonyStyle->createProgressBar(count($filePaths));
+        $progressBarClosure = function (): void {
+=======
+        $this->symfonyStyle->createProgressBar(count($filePaths));
+        $progressBarClosure = function () {
+>>>>>>> 41b8985 (misc)
+            $this->symfonyStyle->progressAdvance();
+        };
+
+=======
+        $progressBarClosure = $this->createProgressBarClosure($isJson, $filePaths);
+>>>>>>> 690f2ba (add progres bar)
+        $measurement = $this->analyser->measureFiles($filePaths, $progressBarClosure);
+<<<<<<< HEAD
+>>>>>>> a97c159 (fixup! misc)
+=======
+>>>>>>> 41b8985 (misc)
 
         // print results
         if ($isJson) {
@@ -71,5 +94,22 @@ final class MeasureCommand extends Command
         }
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * @param string[] $filePaths
+     */
+    private function createProgressBarClosure(bool $isJson, array $filePaths): ?callable
+    {
+        if ($isJson === true) {
+            return null;
+        }
+
+        $progressBar = $this->symfonyStyle->createProgressBar(count($filePaths));
+        $progressBar->start();
+
+        return function () use ($progressBar): void {
+            $progressBar->advance();
+        };
     }
 }

--- a/src/Console/Command/MeasureCommand.php
+++ b/src/Console/Command/MeasureCommand.php
@@ -90,6 +90,7 @@ final class MeasureCommand extends Command
         if ($isJson) {
             $this->jsonOutputFormatter->printMeasurement($measurement, $output, $isShort);
         } else {
+            $this->symfonyStyle->newLine();
             $this->textOutputFormatter->printMeasurement($measurement, $output, $isShort);
         }
 

--- a/src/Console/OutputFormatter/JsonOutputFormatter.php
+++ b/src/Console/OutputFormatter/JsonOutputFormatter.php
@@ -39,12 +39,13 @@ final class JsonOutputFormatter implements OutputFormatterInterface
             $arrayData['structure'] = [
                 'namespaces' => $measurements->getNamespaces(),
                 'classes' => $measurements->getClassCount(),
+                'class_methods' => $measurements->getMethodCount(),
+                'class_constants' => $measurements->getClassConstantCount(),
                 'interfaces' => $measurements->getInterfaceCount(),
                 'traits' => $measurements->getTraitCount(),
                 'enums' => $measurements->getEnumCount(),
-                'constants' => $measurements->getConstantCount(),
-                'methods' => $measurements->getMethodCount(),
                 'functions' => $measurements->getFunctionCount(),
+                'global_constants' => $measurements->getGlobalConstantCount(),
             ];
 
             $arrayData['methods'] = [
@@ -58,16 +59,6 @@ final class JsonOutputFormatter implements OutputFormatterInterface
                 'protected_relative' => $measurements->getProtectedMethodsRelative(),
                 'private' => $measurements->getPrivateMethods(),
                 'private_relative' => $measurements->getPrivateMethodsRelative(),
-            ];
-
-            $arrayData['constants'] = [
-                'class' => $measurements->getClassConstants(),
-                'class_public' => $measurements->getPublicClassConstants(),
-                'class_public_relative' => $measurements->getPublicClassConstantsRelative(),
-                'class_non_public' => $measurements->getNonPublicClassConstants(),
-                'class_non_public_relative' => $measurements->getNonPublicClassConstantsRelative(),
-                'global' => $measurements->getGlobalConstantCount(),
-                'global_relative' => $measurements->getGlobalConstantCountRelative(),
             ];
         }
 

--- a/src/Console/OutputFormatter/JsonOutputFormatter.php
+++ b/src/Console/OutputFormatter/JsonOutputFormatter.php
@@ -15,8 +15,8 @@ final class JsonOutputFormatter implements OutputFormatterInterface
     {
         $arrayData = [
             'filesystem' => [
-                'directories' => $measurements->getDirectories(),
-                'files' => $measurements->getFiles(),
+                'directories' => $measurements->getDirectoryCount(),
+                'files' => $measurements->getFileCount(),
             ],
 
             'lines_of_code' => [

--- a/src/Console/OutputFormatter/TextOutputFormatter.php
+++ b/src/Console/OutputFormatter/TextOutputFormatter.php
@@ -38,7 +38,6 @@ final class TextOutputFormatter implements OutputFormatterInterface
 
         $this->printStructure($measurements);
         $this->printMethods($measurements);
-        $this->printConstants($measurements);
     }
 
     private function printFilesAndDirectories(Measurements $measurements): void
@@ -83,36 +82,13 @@ final class TextOutputFormatter implements OutputFormatterInterface
         $this->tablePrinter->printItemValueTable([
             ['Namespaces', $measurements->getNamespaces()],
             ['Classes', $measurements->getClassCount()],
+            [' * Constants', $measurements->getClassConstantCount()],
+            [' * Methods', $measurements->getMethodCount()],
             ['Interfaces', $measurements->getInterfaceCount()],
             ['Traits', $measurements->getTraitCount()],
             ['Enums', $measurements->getEnumCount()],
-            ['Constants', $measurements->getConstantCount()],
-            ['Methods', $measurements->getMethodCount()],
             ['Functions', $measurements->getFunctionCount()],
+            ['Global constants', $measurements->getGlobalConstantCount()],
         ], 'Structure', 'Count');
-    }
-
-    private function printConstants(Measurements $measurements): void
-    {
-        if ($measurements->getConstantCount() === 0) {
-            return;
-        }
-
-        $constantsRows = [
-            ['Global', $measurements->getGlobalConstantCount(), $measurements->getGlobalConstantCountRelative()],
-            ['Class', $measurements->getClassConstants(), $measurements->getClassConstantCountRelative()],
-        ];
-
-        if ($measurements->getClassConstants() !== 0) {
-            $constantsRows[] = new TableSeparator();
-
-            $constantsRows[] = [
-                'Non-public',
-                $measurements->getNonPublicClassConstants(),
-                $measurements->getNonPublicClassConstantsRelative(),
-            ];
-        }
-
-        $this->tablePrinter->printItemValueTable($constantsRows, 'Constants', 'Count', true);
     }
 }

--- a/src/Console/OutputFormatter/TextOutputFormatter.php
+++ b/src/Console/OutputFormatter/TextOutputFormatter.php
@@ -53,7 +53,8 @@ final class TextOutputFormatter implements OutputFormatterInterface
 
     private function printFilesAndDirectories(Measurements $measurements): void
     {
-        $tableRows = [['Directories', $measurements->getDirectories()], ['Files', $measurements->getFiles()]];
+        $tableRows = [['Directories', $measurements->getDirectoryCount()], ['Files', $measurements->getFileCount()]];
+
         $this->tablePrinter->printItemValueTable($tableRows, 'Metric', 'Count');
     }
 

--- a/src/Console/OutputFormatter/TextOutputFormatter.php
+++ b/src/Console/OutputFormatter/TextOutputFormatter.php
@@ -36,16 +36,6 @@ final class TextOutputFormatter implements OutputFormatterInterface
             ['Method average', $measurements->getAverageMethodLength()],
         ], 'Length Stats', 'Lines');
 
-        $this->tablePrinter->printItemValueTable([
-            ['Classes', $measurements->getClassLinesRelative()],
-            ['Functions', $measurements->getFunctionLinesRelative()],
-            [
-                'Not in classes/functions',
-                $measurements->getNotInClassesOrFunctions(),
-                $measurements->getNotInClassesOrFunctionsRelative(),
-            ],
-        ], 'Classes vs functions vs rest', null, true);
-
         $this->printStructure($measurements);
         $this->printMethods($measurements);
         $this->printConstants($measurements);

--- a/src/Console/OutputFormatter/TextOutputFormatter.php
+++ b/src/Console/OutputFormatter/TextOutputFormatter.php
@@ -37,14 +37,14 @@ final class TextOutputFormatter implements OutputFormatterInterface
         ], 'Length Stats', 'Lines');
 
         $this->tablePrinter->printItemValueTable([
-            ['Classes', $measurements->getClassLines(), $measurements->getClassLinesRelative()],
-            ['Functions', $measurements->getFunctionLines(), $measurements->getFunctionLinesRelative()],
+            ['Classes', $measurements->getClassLinesRelative()],
+            ['Functions', $measurements->getFunctionLinesRelative()],
             [
                 'Not in classes/functions',
                 $measurements->getNotInClassesOrFunctions(),
                 $measurements->getNotInClassesOrFunctionsRelative(),
             ],
-        ], 'Classes vs functions vs rest', 'Lines', true);
+        ], 'Classes vs functions vs rest', null, true);
 
         $this->printStructure($measurements);
         $this->printMethods($measurements);

--- a/src/Console/TablePrinter.php
+++ b/src/Console/TablePrinter.php
@@ -28,10 +28,14 @@ final class TablePrinter
     public function printItemValueTable(
         array $rows,
         string $titleHeader,
-        string $countHeader,
+        ?string $countHeader = null,
         bool $includeRelative = false
     ): void {
-        $headers = [$titleHeader, $countHeader];
+        $headers = [$titleHeader];
+        if ($countHeader !== null) {
+            $headers[] = $countHeader;
+        }
+
         if ($includeRelative) {
             $headers[] = 'Relative';
         }
@@ -44,7 +48,7 @@ final class TablePrinter
             ->setRows($formattedRows)
             ->setColumnStyle(1, $this->padLeftTableStyle);
 
-        if ($includeRelative) {
+        if ($includeRelative && $countHeader !== null) {
             $table->setColumnWidth(1, 8)
                 ->setColumnWidth(2, 7)
                 ->setColumnStyle(2, $this->padLeftTableStyle);

--- a/src/Console/TablePrinter.php
+++ b/src/Console/TablePrinter.php
@@ -28,14 +28,10 @@ final class TablePrinter
     public function printItemValueTable(
         array $rows,
         string $titleHeader,
-        ?string $countHeader = null,
+        string $countHeader,
         bool $includeRelative = false
     ): void {
-        $headers = [$titleHeader];
-        if ($countHeader !== null) {
-            $headers[] = $countHeader;
-        }
-
+        $headers = [$titleHeader, $countHeader];
         if ($includeRelative) {
             $headers[] = 'Relative';
         }
@@ -48,7 +44,7 @@ final class TablePrinter
             ->setRows($formattedRows)
             ->setColumnStyle(1, $this->padLeftTableStyle);
 
-        if ($includeRelative && $countHeader !== null) {
+        if ($includeRelative) {
             $table->setColumnWidth(1, 8)
                 ->setColumnWidth(2, 7)
                 ->setColumnStyle(2, $this->padLeftTableStyle);

--- a/src/Finder/PhpFilesFinder.php
+++ b/src/Finder/PhpFilesFinder.php
@@ -10,24 +10,37 @@ use Webmozart\Assert\Assert;
 final class PhpFilesFinder
 {
     /**
-     * @param string[] $directories
+     * @param string[] $paths
      * @param string[] $exclude
      * @return string[]
      */
-    public function findInDirectories(array $directories, array $exclude = []): array
+    public function findInDirectories(array $paths, array $exclude = []): array
     {
-        $phpFilesFinder = Finder::create()
-            ->files()
-            ->in($directories)
-            ->name('*.php')
-            ->exclude($exclude);
-
-        // skip yourself
-        $phpFilesFinder->notPath('tomasvotruba/lines');
+        Assert::allFileExists($paths);
 
         $filePaths = [];
-        foreach ($phpFilesFinder->getIterator() as $fileInfo) {
-            $filePaths[] = $fileInfo->getRealPath();
+        $directories = [];
+
+        foreach ($paths as $path) {
+            if (is_file($path)) {
+                $filePaths[] = $path;
+            } else {
+                $directories[] = $path;
+            }
+        }
+
+        if ($directories !== []) {
+            $phpFilesFinder = Finder::create()
+                ->files()
+                ->in($directories)
+                ->name('*.php')
+                // skip this package in /vendor
+                ->notPath('tomasvotruba/lines')
+                ->exclude($exclude);
+
+            foreach ($phpFilesFinder->getIterator() as $fileInfo) {
+                $filePaths[] = $fileInfo->getRealPath();
+            }
         }
 
         Assert::allString($filePaths);

--- a/src/Measurements.php
+++ b/src/Measurements.php
@@ -200,13 +200,13 @@ final class Measurements
         ++$this->enumCount;
     }
 
-    public function getDirectories(): int
+    public function getDirectoryCount(): int
     {
         $uniqueDirectoryNames = array_unique($this->directoryNames);
         return count($uniqueDirectoryNames) - 1;
     }
 
-    public function getFiles(): int
+    public function getFileCount(): int
     {
         return $this->fileCount;
     }

--- a/src/Measurements.php
+++ b/src/Measurements.php
@@ -243,6 +243,9 @@ final class Measurements
         return 0.0;
     }
 
+    /**
+     * @api used only in tests
+     */
     public function getClassLines(): int
     {
         return array_sum($this->classLineCountPerClass);
@@ -278,11 +281,17 @@ final class Measurements
         return max($this->methodLineCountPerMethod);
     }
 
+    /**
+     * @api used in only in tests
+     */
     public function getFunctionLines(): int
     {
         return $this->functionLineCount;
     }
 
+    /**
+     * @api used in only in tests
+     */
     public function getNotInClassesOrFunctions(): int
     {
         return $this->logicalLineCount - $this->getClassLines() - $this->functionLineCount;

--- a/src/Measurements.php
+++ b/src/Measurements.php
@@ -234,15 +234,6 @@ final class Measurements
         return $this->logicalLineCount;
     }
 
-    public function getClassLinesRelative(): float
-    {
-        if ($this->logicalLineCount > 0) {
-            return $this->relative($this->getClassLines(), $this->logicalLineCount);
-        }
-
-        return 0.0;
-    }
-
     /**
      * @api used only in tests
      */
@@ -391,24 +382,6 @@ final class Measurements
     {
         if ($this->lineCount !== 0) {
             return $this->relative($this->getNonCommentLines(), $this->lineCount);
-        }
-
-        return 0.0;
-    }
-
-    public function getFunctionLinesRelative(): float
-    {
-        if ($this->logicalLineCount > 0) {
-            return $this->relative($this->functionLineCount, $this->logicalLineCount);
-        }
-
-        return 0.0;
-    }
-
-    public function getNotInClassesOrFunctionsRelative(): float
-    {
-        if ($this->logicalLineCount > 0) {
-            return $this->relative($this->getNotInClassesOrFunctions(), $this->logicalLineCount);
         }
 
         return 0.0;

--- a/src/Measurements.php
+++ b/src/Measurements.php
@@ -344,27 +344,12 @@ final class Measurements
         return $this->functionCount;
     }
 
-    public function getConstantCount(): int
-    {
-        return $this->globalConstantCount + $this->getClassConstants();
-    }
-
     public function getGlobalConstantCount(): int
     {
         return $this->globalConstantCount;
     }
 
-    public function getPublicClassConstants(): int
-    {
-        return $this->publicClassConstantCount;
-    }
-
-    public function getNonPublicClassConstants(): int
-    {
-        return $this->nonPublicClassConstantCount;
-    }
-
-    public function getClassConstants(): int
+    public function getClassConstantCount(): int
     {
         return $this->publicClassConstantCount + $this->nonPublicClassConstantCount;
     }
@@ -427,42 +412,6 @@ final class Measurements
     {
         if ($this->getMethodCount() !== 0) {
             return $this->relative($this->privateMethodCount, $this->getMethodCount());
-        }
-
-        return 0.0;
-    }
-
-    public function getGlobalConstantCountRelative(): float
-    {
-        if ($this->getConstantCount() !== 0) {
-            return $this->relative($this->globalConstantCount, $this->getConstantCount());
-        }
-
-        return 0.0;
-    }
-
-    public function getClassConstantCountRelative(): float
-    {
-        if ($this->getConstantCount() !== 0) {
-            return $this->relative($this->getClassConstants(), $this->getConstantCount());
-        }
-
-        return 0.0;
-    }
-
-    public function getPublicClassConstantsRelative(): float
-    {
-        if ($this->getClassConstants() !== 0) {
-            return $this->relative($this->publicClassConstantCount, $this->getClassConstants());
-        }
-
-        return 0.0;
-    }
-
-    public function getNonPublicClassConstantsRelative(): float
-    {
-        if ($this->getClassConstants() !== 0) {
-            return $this->relative($this->nonPublicClassConstantCount, $this->getClassConstants());
         }
 
         return 0.0;

--- a/tests/AnalyserTest.php
+++ b/tests/AnalyserTest.php
@@ -39,10 +39,7 @@ final class AnalyserTest extends TestCase
         $this->assertSame(1, $measurements->getPrivateMethods());
         $this->assertSame(3, $measurements->getNonStaticMethods());
         $this->assertSame(1, $measurements->getStaticMethods());
-        $this->assertSame(2, $measurements->getConstantCount());
-        $this->assertSame(1, $measurements->getClassConstants());
-        $this->assertSame(1, $measurements->getPublicClassConstants());
-        $this->assertSame(0, $measurements->getNonPublicClassConstants());
+        $this->assertSame(1, $measurements->getClassConstantCount());
         $this->assertSame(1, $measurements->getGlobalConstantCount());
         $this->assertSame(0, $measurements->getDirectoryCount());
         $this->assertSame(1, $measurements->getNamespaces());
@@ -87,11 +84,8 @@ final class AnalyserTest extends TestCase
     {
         $measurements = $this->analyser->measureFiles([__DIR__ . '/Fixture/class_constants.php']);
 
-        $this->assertSame(2, $measurements->getPublicClassConstants());
-        $this->assertSame(3, $measurements->getNonPublicClassConstants());
-
-        $this->assertSame(5, $measurements->getClassConstants());
-        $this->assertSame(5, $measurements->getConstantCount());
+        $this->assertSame(5, $measurements->getClassConstantCount());
+        $this->assertSame(1, $measurements->getGlobalConstantCount());
     }
 
     public function testClasses(): void

--- a/tests/AnalyserTest.php
+++ b/tests/AnalyserTest.php
@@ -22,7 +22,7 @@ final class AnalyserTest extends TestCase
     {
         $measurements = $this->analyser->measureFiles([__DIR__ . '/Fixture/source.php']);
 
-        $this->assertSame(1, $measurements->getFiles());
+        $this->assertSame(1, $measurements->getFileCount());
         $this->assertSame(82, $measurements->getLines());
         $this->assertSame(30, $measurements->getLogicalLines());
         $this->assertSame(28, $measurements->getClassLines());
@@ -44,7 +44,7 @@ final class AnalyserTest extends TestCase
         $this->assertSame(1, $measurements->getPublicClassConstants());
         $this->assertSame(0, $measurements->getNonPublicClassConstants());
         $this->assertSame(1, $measurements->getGlobalConstantCount());
-        $this->assertSame(0, $measurements->getDirectories());
+        $this->assertSame(0, $measurements->getDirectoryCount());
         $this->assertSame(1, $measurements->getNamespaces());
         $this->assertSame(75, $measurements->getNonCommentLines());
 

--- a/tests/AnalyserTest.php
+++ b/tests/AnalyserTest.php
@@ -57,10 +57,7 @@ final class AnalyserTest extends TestCase
 
         // relative
         $this->assertSame(8.5, $measurements->getCommentLinesRelative());
-        $this->assertSame(3.3, $measurements->getFunctionLinesRelative());
-        $this->assertSame(93.3, $measurements->getClassLinesRelative());
         $this->assertSame(91.5, $measurements->getNonCommentLinesRelative());
-        $this->assertSame(3.3, $measurements->getNotInClassesOrFunctionsRelative());
 
         $this->assertSame(25.0, $measurements->getStaticMethodsRelative());
         $this->assertSame(75.0, $measurements->getNonStaticMethodsRelative());

--- a/tests/Fixture/class_constants.php
+++ b/tests/Fixture/class_constants.php
@@ -1,5 +1,7 @@
 <?php
 
+define('SOME_CONSTANT', 'some_value');
+
 class ClassConstants
 {
     final public const IMPLICITLY_PUBLIC_CONSTANT = 'implicitly public';


### PR DESCRIPTION
Overview with classes and functions does not make sense, as now there are also triats, functions, global constants, enums etc. To keep data readable, class constant and global constants are now moved to structure overview :+1: 

```json
{
    "filesystem": {
        "directories": 1887,
        "files": 7673
    },
    "lines_of_code": {
        "code": 521791,
        "code_relative": 70.3,
        "comments": 220205,
        "comments_relative": 29.7,
        "total": 741996
    },
    "lengths": {
        "class_max": 987,
        "class_average": 7,
        "method_max": 568,
        "method_average": 3.9
    },
    "structure": {
        "namespaces": 1700,
        "classes": 6248,
        "class_methods": 36663,
        "class_constants": 3351,
        "interfaces": 1070,
        "traits": 98,
        "enums": 3,
        "functions": 6254,
        "global_constants": 35
    },
    "methods": {
        "non_static": 32063,
        "non_static_relative": 87.5,
        "static": 4600,
        "static_relative": 12.5,
        "public": 28964,
        "public_relative": 79,
        "protected": 2484,
        "protected_relative": 6.8,
        "private": 5215,
        "private_relative": 14.2
    }
}

```