### PR TITLE
Add Key Value output formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ CLI tool for quick size measure of PHP project, runs anywhere
 * install anywhere - PHP 7.2? PHPUnit 6? Symfony 3? Not a problem, this package **has zero dependencies and works on PHP 7.2+**
 * get quick overview of your project size - no details, no complexity, just lines of code
 * get easy JSON output for further processing
+* get easy Key=Value output for further processing
 * we keep it simple, so you can enjoy reading - for more complex operation use static analysis like PHPStan
 
 <br>
@@ -35,6 +36,12 @@ For json output, just add `--json`:
 
 ```bash
 vendor/bin/lines measure src --json
+```
+
+For key value output, just add `--key-value`:
+
+```bash
+vendor/bin/lines measure src --key-value
 ```
 
 Also, you can combine them (very handy for blog posts and tweets):
@@ -119,7 +126,11 @@ Or in a json format:
     }
 }
 ```
+Or in key value format:
 
+```
+directories=27,files=86,code=3580,code_relative=92.9,comments=274,comments_relative=7.1,total=3854,namespaces=28,classes=81,class_methods=231,class_constants=17,interfaces=2,traits=1,enums=2,functions=0,global_constants=0,non_static=210,non_static_relative=90.9,static=21,static_relative=9.1,public=205,public_relative=88.7,protected=7,protected_relative=3,private=19,private_relative=8.2
+```
 
 ## Vendor file scanning
 

--- a/src/Console/OutputFormatter/KeyValueOutputFormatter.php
+++ b/src/Console/OutputFormatter/KeyValueOutputFormatter.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\Lines\Console\OutputFormatter;
+
+use TomasVotruba\Lines\Contract\OutputFormatterInterface;
+use TomasVotruba\Lines\Measurements;
+
+final class KeyValueOutputFormatter implements OutputFormatterInterface
+{
+    public function printMeasurement(Measurements $measurements, bool $isShort): void
+    {
+        $arrayData = [
+            'directories' => $measurements->getDirectoryCount(),
+            'files' => $measurements->getFileCount(),
+            'code' => $measurements->getNonCommentLines(),
+            'code_relative' => $measurements->getNonCommentLinesRelative(),
+            'comments' => $measurements->getCommentLines(),
+            'comments_relative' => $measurements->getCommentLinesRelative(),
+            'total' => $measurements->getLines(),
+        ];
+
+        if ($isShort === false) {
+            $extraData = [
+                'namespaces' => $measurements->getNamespaceCount(),
+                'classes' => $measurements->getClassCount(),
+                'class_methods' => $measurements->getMethodCount(),
+                'class_constants' => $measurements->getClassConstantCount(),
+                'interfaces' => $measurements->getInterfaceCount(),
+                'traits' => $measurements->getTraitCount(),
+                'enums' => $measurements->getEnumCount(),
+                'functions' => $measurements->getFunctionCount(),
+                'global_constants' => $measurements->getGlobalConstantCount(),
+                'non_static' => $measurements->getNonStaticMethods(),
+                'non_static_relative' => $measurements->getNonStaticMethodsRelative(),
+                'static' => $measurements->getStaticMethods(),
+                'static_relative' => $measurements->getStaticMethodsRelative(),
+                'public' => $measurements->getPublicMethods(),
+                'public_relative' => $measurements->getPublicMethodsRelative(),
+                'protected' => $measurements->getProtectedMethods(),
+                'protected_relative' => $measurements->getProtectedMethodsRelative(),
+                'private' => $measurements->getPrivateMethods(),
+                'private_relative' => $measurements->getPrivateMethodsRelative(),
+            ];
+
+            $arrayData = array_merge($arrayData, $extraData);
+        }
+
+        $keyValuePairs = [];
+        foreach ($arrayData as $key => $value) {
+            $keyValuePairs[] = $key . '=' . $value;
+        }
+
+        $keyValueString = implode(',', $keyValuePairs);
+
+        echo $keyValueString . PHP_EOL;
+    }
+}


### PR DESCRIPTION
Here is an additional output formatter that simply creates a single line of comma separated key-value pairs.

The use-case is for ingesting the output of the measure command into InfluxDB, which is a data source for Grafana - basically so we can have nice dashboards showing the history of LOC, number of static methods etc from each CI build.