### PR TITLE
feat: support relative paths on Windows

### DIFF
--- a/src/Measurements.php
+++ b/src/Measurements.php
@@ -59,7 +59,7 @@ final class Measurements
     {
         $this->directoryNames[] = dirname($filename);
 
-        $relativeFilePath = str_replace(getcwd() . '/', '', $filename);
+        $relativeFilePath = str_replace(getcwd() . PHP_EOL, '', $filename);
         $this->filesToSize[$relativeFilePath] = substr_count((string) file_get_contents($filename), "\n") + 1;
 
         ++$this->fileCount;


### PR DESCRIPTION
Fixes an issue on Windows where the `measure --longest` command printed absolute file paths instead of relative ones.

## Before:
<img height="256" alt="grafik" src="https://github.com/user-attachments/assets/9949775a-7c42-413a-9b16-9f7205dc8543" />

## After:
<img height="256" alt="grafik" src="https://github.com/user-attachments/assets/5523d388-895c-414e-9f77-3e8d3c9a64bb" />
